### PR TITLE
Fix #5, compile issue due to generics craziness

### DIFF
--- a/src/test/java/com/soulgalore/jdbcmetrics/driver/WhenDriverIsRegistered.java
+++ b/src/test/java/com/soulgalore/jdbcmetrics/driver/WhenDriverIsRegistered.java
@@ -1,6 +1,7 @@
 package com.soulgalore.jdbcmetrics.driver;
 
 import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 import java.sql.Driver;
@@ -16,7 +17,14 @@ public class WhenDriverIsRegistered extends AbstractDriverTest {
 	@Test
 	public void driverShouldBeInDriverManager() {
 		List<Driver> driversInManager = Collections.list(DriverManager.getDrivers());
-		assertThat(driversInManager, hasItem(isA(JDBCMetricsDriver.class)));
+        boolean foundJDBCMetricsDriver = false;
+        for (Driver driver : driversInManager) {
+            if (driver instanceof JDBCMetricsDriver) {
+                foundJDBCMetricsDriver = true;
+                break;
+            }
+        }
+        assertThat("JDBCMetricsDriver should be registered in DriverManager", foundJDBCMetricsDriver);
 		assertThat(underlayingDriver, isIn(driversInManager));
 	}
 


### PR DESCRIPTION
When compiling at the command line, via mvn compile, compilation fails with the following error:
[ERROR] /Users/tobli/Development/jdbcmetrics/src/test/java/com/soulgalore/jdbcmetrics/driver/WhenDriverIsRegistered.java:[19,2] cannot find symbol
symbol  : method assertThat(java.util.List<java.sql.Driver>,org.hamcrest.Matcher<java.lang.Iterable<? super java.lang.Object>>)
location: class com.soulgalore.jdbcmetrics.driver.WhenDriverIsRegistered
This issue is noted in http://code.google.com/p/hamcrest/issues/detail?id=167
Work around by replacing Hamcrest matchers with for-loop.
