### PR TITLE
Fix order dependency in tests by resetting static variable before every test

### DIFF
--- a/src/test/java/com/soulgalore/jdbcmetrics/filter/WhenTheFilterIsRunning.java
+++ b/src/test/java/com/soulgalore/jdbcmetrics/filter/WhenTheFilterIsRunning.java
@@ -14,6 +14,7 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.soulgalore.jdbcmetrics.QueryThreadLocal;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -22,8 +23,8 @@ public class WhenTheFilterIsRunning {
 
 	@Before
 	public void setUp() throws Exception {
-
-	}
+        QueryThreadLocal.removeNrOfQueries();
+    }
 
 	@Test
 	public void anEmptyInitParameterShouldFallbackToDefault() {


### PR DESCRIPTION
Sometimes when running tests (always from within IntelliJ IDEA) the headersShouldBeSetWhenRightHeaderIsSupplied test will fail. This is because the QueryThreadLocal state was not cleared between tests. Fix by clearing thread local in setUp.
