### PR TITLE
Fix warnings in log while running tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,14 @@
 			<version>1.6.6</version>
 		</dependency>
 
-		<dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.6.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
 			<version>2.5</version>


### PR DESCRIPTION
When running tests sl4j would print warnings in the logs.
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Prevent this by adding slf4j-simple.jar in the test scope, to enable a proper logger for the tests.
