### PR TITLE
Set servlet-api to provided scope to avoid conflicts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
 			<version>2.5</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Woho, testing! -->


### PR DESCRIPTION
As the servlet API is already present in servlet containers, it is wrong to put it in compile scope.

In my case, it even created a compile-time problem in Eclipse, because I had the servlet 3.0 API in test scope and it was replaced by the 2.5 API, leading to missing methods.
