### PR TITLE
Updated to Metrics 3.0.1. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Then set it up in your **web.xml**:
 </pre>
 
 ###Choose registry###
-The default <em>MetricRegistry</em> is used by default, if you want a new to be created 
-add the System property <em>com.soulgalore.jdbcmetrics.MetricRegistry</em> with the value <em>new</em>.
+A new <em>MetricRegistry</em> is used by default. If you want to retrieve one from <em>SharedMetricRegistries</em>,
+set the System property <em>com.soulgalore.jdbcmetrics.MetricRegistry</em> to the name of the registry you wish to use.
 
 ## Fetching info from individual request(s)
 You can get information on how many database reads & writes your request generates by two different ways: Either it is logged to your log system or you can get it as response headers

--- a/pom.xml
+++ b/pom.xml
@@ -50,12 +50,11 @@
 	</parent>
 
 	<dependencies>
-
 		<!-- Collecting statistics the best way -->
 		<dependency>
-			<groupId>com.yammer.metrics</groupId>
+			<groupId>com.codahale.metrics</groupId>
 			<artifactId>metrics-core</artifactId>
-			<version>2.2.0</version>
+			<version>3.0.1</version>
 		</dependency>
 		<!-- same version as metrics -->
 		<dependency>

--- a/src/main/java/com/soulgalore/jdbcmetrics/ConnectionPoolDataSource.java
+++ b/src/main/java/com/soulgalore/jdbcmetrics/ConnectionPoolDataSource.java
@@ -1,19 +1,19 @@
 /******************************************************
  * JDBCMetrics
- * 
+ *
  *
  * Copyright (C) 2013 by Magnus Lundberg (http://magnuslundberg.com) & Peter Hedenskog (http://peterhedenskog.com)
  *
  ******************************************************
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
- * 
+ *
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is 
- * distributed  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
  *
  *******************************************************
@@ -24,9 +24,8 @@ import java.sql.SQLException;
 
 import javax.sql.PooledConnection;
 
-import com.yammer.metrics.core.Timer;
-import com.yammer.metrics.core.TimerContext;
-
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.Timer.Context;
 
 public class ConnectionPoolDataSource extends AbstractCommonDataSource<javax.sql.ConnectionPoolDataSource>
 		implements javax.sql.ConnectionPoolDataSource {
@@ -36,7 +35,7 @@ public class ConnectionPoolDataSource extends AbstractCommonDataSource<javax.sql
 		super();
 		timer = JDBCMetrics.getInstance().getWaitForConnectionInPool();
 	}
-	
+
 	public ConnectionPoolDataSource(javax.sql.ConnectionPoolDataSource dataSource) {
 		super(dataSource);
 		timer = JDBCMetrics.getInstance().getWaitForConnectionInPool();
@@ -47,11 +46,11 @@ public class ConnectionPoolDataSource extends AbstractCommonDataSource<javax.sql
 		super(referenceName);
 		 timer = JDBCMetrics.getInstance().getWaitForConnectionInPool();
 	}
-	
+
 	@Override
 	public PooledConnection getPooledConnection() throws SQLException {
-		
-		final TimerContext context = timer.time();
+
+		final Context context = timer.time();
 		try {
 			PooledConnection connection = getDataSource().getPooledConnection();
 			if (connection != null) {
@@ -61,13 +60,13 @@ public class ConnectionPoolDataSource extends AbstractCommonDataSource<javax.sql
 		} finally {
 			context.stop();
 		}
-		
+
 	}
 
 	@Override
 	public PooledConnection getPooledConnection(String user, String password)
 			throws SQLException {
-		final TimerContext context = timer.time();
+	  final Context context = timer.time();
 		try {
 			PooledConnection connection = getDataSource().getPooledConnection(
 					user, password);

--- a/src/main/java/com/soulgalore/jdbcmetrics/JDBCMetrics.java
+++ b/src/main/java/com/soulgalore/jdbcmetrics/JDBCMetrics.java
@@ -1,54 +1,53 @@
 /******************************************************
  * JDBCMetrics
- * 
+ *
  *
  * Copyright (C) 2013 by Magnus Lundberg (http://magnuslundberg.com) & Peter Hedenskog (http://peterhedenskog.com)
  *
  ******************************************************
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  * compliance with the License. You may obtain a copy of the License at
- * 
+ *
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is 
- * distributed  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
  *
  *******************************************************
  */
 package com.soulgalore.jdbcmetrics;
 
-import java.util.concurrent.TimeUnit;
+import javax.management.ObjectName;
 
-import com.yammer.metrics.Metrics;
-import com.yammer.metrics.core.Histogram;
-import com.yammer.metrics.core.Timer;
-import com.yammer.metrics.core.MetricName;
-import com.yammer.metrics.core.MetricsRegistry;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import com.codahale.metrics.Timer;
 
 /**
  * Class responsible for holding all the Yammer Metrics.
- * The default MetricRegistry is used by default, if you want a new to be created 
- * add a System property  
+ * The default MetricRegistry is used by default, if you want a new to be created
+ * add a System property
  * <em>com.soulgalore.jdbcmetrics.MetricRegistry</em> with the value <em>new</em>.
  *
  */
 public class JDBCMetrics {
 
 	public static final String REGISTRY_PROPERTY_NAME = "com.soulgalore.jdbcmetrics.MetricRegistry";
-	
+
 	private static final String GROUP = "jdbc";
 	private static final String GROUP_POOL = "connectionpool";
 	private static final String TYPE_READ = "read";
 	private static final String TYPE_WRITE = "write";
 	private static final String TYPE_READ_OR_WRITE = "readorwrite";
-	
+
 	private static final String REGISTRY_DEFAULT = "default";
-	
-	private final MetricsRegistry registry; 
-	
+
+	private final MetricRegistry registry;
+
 	private final Histogram readCountsPerRequest;
 	private final Histogram writeCountsPerRequest;
 
@@ -57,45 +56,43 @@ public class JDBCMetrics {
 	private final Timer writeTimerPerRequest;
 	private final Timer readTimerPerRequest;
 	private final Timer connectionPoolTimer;
-	
+
 	private static final JDBCMetrics INSTANCE = new JDBCMetrics();
 
-	
+
 	private JDBCMetrics() {
-		
-		String propertyValue = System.getProperty(REGISTRY_PROPERTY_NAME,REGISTRY_DEFAULT);
-		if (REGISTRY_DEFAULT.equals(propertyValue))
-			registry = Metrics.defaultRegistry();
+
+		String propertyValue = System.getProperty(REGISTRY_PROPERTY_NAME);
+		if (propertyValue != null)
+			registry = SharedMetricRegistries.getOrCreate(propertyValue);
 		else
-			registry = new MetricsRegistry();
-	
-		
-		readCountsPerRequest = registry.newHistogram(new MetricName(
-				GROUP, TYPE_READ, "read-counts-per-request"), true);
-		
-		 writeCountsPerRequest = registry.newHistogram(new MetricName(
-					GROUP, TYPE_WRITE, "write-counts-per-request"), true);
-		 
-		 writeTimer = registry.newTimer(new MetricName(GROUP,
-					TYPE_WRITE, "write-time"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
-		 
-		 readTimer = registry.newTimer(new MetricName(GROUP,
-					TYPE_READ, "read-time"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
-		 
-		 writeTimerPerRequest = registry.newTimer(new MetricName(GROUP,
-					TYPE_WRITE, "write-time-per-request"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
-		 
-		 readTimerPerRequest = registry.newTimer(new MetricName(GROUP,
-					TYPE_READ, "read-time-per-request"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
-		 
-		 
-		 connectionPoolTimer = registry.newTimer(new MetricName(GROUP_POOL,
-				 TYPE_READ_OR_WRITE, "wait-for-connection"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+			registry = new MetricRegistry();
+
+		readCountsPerRequest = registry.histogram(createName(
+				GROUP, TYPE_READ, "read-counts-per-request"));
+
+		 writeCountsPerRequest = registry.histogram(createName(
+					GROUP, TYPE_WRITE, "write-counts-per-request"));
+
+		 writeTimer = registry.timer(createName(GROUP,
+					TYPE_WRITE, "write-time"));
+
+		 readTimer = registry.timer(createName(GROUP,
+					TYPE_READ, "read-time"));
+
+		 writeTimerPerRequest = registry.timer(createName(GROUP,
+					TYPE_WRITE, "write-time-per-request"));
+
+		 readTimerPerRequest = registry.timer(createName(GROUP,
+					TYPE_READ, "read-time-per-request"));
+
+		 connectionPoolTimer = registry.timer(createName(GROUP_POOL,
+		     TYPE_READ_OR_WRITE, "wait-for-connection"));
 	}
 
 	/**
 	 * Get the instance.
-	 * 
+	 *
 	 * @return the singleton instance.
 	 */
 	public static JDBCMetrics getInstance() {
@@ -110,20 +107,20 @@ public class JDBCMetrics {
 	public Histogram getWriteCountsPerRequest() {
 		return writeCountsPerRequest;
 	}
-	
+
 	public Timer getWriteTimer() {
 		return writeTimer;
 	}
-	
+
 	public Timer getReadTimer() {
 		return readTimer;
 	}
-	
+
 	public Timer getWaitForConnectionInPool() {
 		return connectionPoolTimer;
 	}
-	
-	public MetricsRegistry getRegistry() {
+
+	public MetricRegistry getRegistry() {
 		return registry;
 	}
 
@@ -135,4 +132,16 @@ public class JDBCMetrics {
 		return readTimerPerRequest;
 	}
 
+  private static String createName(String group, String type, String name) {
+    final StringBuilder nameBuilder = new StringBuilder();
+    nameBuilder.append(ObjectName.quote(group));
+    nameBuilder.append(":type=");
+    nameBuilder.append(ObjectName.quote(type));
+    if (name.length() > 0) {
+      nameBuilder.append(",name=");
+      nameBuilder.append(ObjectName.quote(name));
+    }
+
+    return nameBuilder.toString();
+  }
 }

--- a/src/test/java/com/soulgalore/jdbcmetrics/proxy/WhenQueryIsExecuted.java
+++ b/src/test/java/com/soulgalore/jdbcmetrics/proxy/WhenQueryIsExecuted.java
@@ -1,7 +1,8 @@
 package com.soulgalore.jdbcmetrics.proxy;
 
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -19,26 +20,26 @@ public class WhenQueryIsExecuted extends AbstractDriverTest {
 
 	Connection connection;
 	Statement statement;
-	
+
 	@Before
 	public void setup() throws SQLException {
 		connection = driver.connect(URL_JDBC_METRICS, null);
 		assertThat(connection, notNullValue());
 		statement = connection.createStatement();
 		assertThat(statement, notNullValue());
-		
+
 		QueryThreadLocal.init();
 		assertThat(reads(), is(0));
 		assertThat(writes(), is(0));
 	}
-	
+
 	@Test
 	public void executeShouldIncreaseReadCounter() throws SQLException {
 		statement.execute("SELECT 1");
 		assertThat(reads(), is(1));
 		assertThat(writes(), is(0));
 	}
-	
+
 	@Test
 	public void executeShouldIncreaseWriteCounter() throws SQLException {
 		statement.execute("INSERT 1 (SELECT 2)");
@@ -80,7 +81,7 @@ public class WhenQueryIsExecuted extends AbstractDriverTest {
 		assertThat(reads(), is(0));
 		assertThat(writes(), is(0));
 	}
-	
+
 	@Test
 	public void executePreparedStatementShouldIncreaseReadCounter() throws SQLException {
 		PreparedStatement pst = connection.prepareStatement("SELECT 1");
@@ -88,7 +89,7 @@ public class WhenQueryIsExecuted extends AbstractDriverTest {
 		assertThat(reads(), is(1));
 		assertThat(writes(), is(0));
 	}
-	
+
 	@Test
 	public void executePreparedStatementShouldIncreaseWriteCounter() throws SQLException {
 		PreparedStatement pst = connection.prepareStatement("INSERT 1");
@@ -104,7 +105,7 @@ public class WhenQueryIsExecuted extends AbstractDriverTest {
 		assertThat(reads(), is(1));
 		assertThat(writes(), is(0));
 	}
-	
+
 	@Test
 	public void executeCallableStatementShouldIncreaseWriteCounter() throws SQLException {
 		CallableStatement cst = connection.prepareCall("INSERT 1");
@@ -112,7 +113,7 @@ public class WhenQueryIsExecuted extends AbstractDriverTest {
 		assertThat(reads(), is(0));
 		assertThat(writes(), is(1));
 	}
-	
+
 	@Test
 	public void allPrepareStatementsExecuteShouldIncreaseCounter() throws SQLException {
 
@@ -142,37 +143,37 @@ public class WhenQueryIsExecuted extends AbstractDriverTest {
 			pst.executeBatch();
 			assertThat(reads(), is(8));
 			assertThat(writes(), is(0));
-			
+
 		} finally {
 			if (pst != null)
 				pst.close();
 		}
-		
-	}
-	
-	
-	@Test
-	public void executeSelectShouldIncreaseReadTimer() throws SQLException {
-		long oldValue = JDBCMetrics.getInstance().getReadTimer().count();
-		PreparedStatement pst = connection.prepareStatement("SELECT 1");
-		pst.execute();
-		assertThat(JDBCMetrics.getInstance().getReadTimer().count(), is(oldValue+1));
+
 	}
 
-	
+
+	@Test
+	public void executeSelectShouldIncreaseReadTimer() throws SQLException {
+		long oldValue = JDBCMetrics.getInstance().getReadTimer().getCount();
+		PreparedStatement pst = connection.prepareStatement("SELECT 1");
+		pst.execute();
+		assertThat(JDBCMetrics.getInstance().getReadTimer().getCount(), is(oldValue+1));
+	}
+
+
 	@Test
 	public void executeInsertShouldIncreaseWriteTimer() throws SQLException {
-		long oldValue = JDBCMetrics.getInstance().getWriteTimer().count();
+		long oldValue = JDBCMetrics.getInstance().getWriteTimer().getCount();
 		PreparedStatement pst = connection.prepareStatement("INSERT 1");
 		pst.execute();
-		assertThat(JDBCMetrics.getInstance().getWriteTimer().count(), is(oldValue+1));
+		assertThat(JDBCMetrics.getInstance().getWriteTimer().getCount(), is(oldValue+1));
 	}
-	
-	
+
+
 	private int reads() {
 		return QueryThreadLocal.getNrOfQueries().getReads();
 	}
-	
+
 	private int writes() {
 		return QueryThreadLocal.getNrOfQueries().getWrites();
 	}


### PR DESCRIPTION
Beware of change in MetricRegistry instance selection: by default a new instance is created and if a system property is set, its value is used as the name in the SharedMetricRegistries.
