### PR TITLE
Fix issue generating sources by deleting '&' from doc

### DIFF
--- a/src/main/java/com/soulgalore/jdbcmetrics/ReadAndWrites.java
+++ b/src/main/java/com/soulgalore/jdbcmetrics/ReadAndWrites.java
@@ -23,7 +23,7 @@
 package com.soulgalore.jdbcmetrics;
 
 /**
- * Hold read & writes per request. The class is not thread safe but is used within a ThreadLocal.
+ * Hold read and writes per request. The class is not thread safe but is used within a ThreadLocal.
  * 
  */
 public class ReadAndWrites {


### PR DESCRIPTION
When running mvn clean install in Java 8 with maven 3.2.1, I encountered the following error:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 7.310 s
[INFO] Finished at: 2015-04-21T10:55:57-06:00
[INFO] Final Memory: 21M/212M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.8:jar (attach-javadocs) on project jdbcmetrics: MavenReportException: Error while creating archive:
[ERROR] Exit code: 1 - /Users/ar026626/git/jdbcmetrics/src/main/java/com/soulgalore/jdbcmetrics/ReadAndWrites.java:26: error: bad HTML entity
[ERROR] * Hold read & writes per request. The class is not thread safe but is used within a ThreadLocal.
[ERROR] ^
[ERROR] 
[ERROR] Command line was: /Library/Java/JavaVirtualMachines/jdk1.8.0_40.jdk/Contents/Home/bin/javadoc @options @packages
[ERROR] 
[ERROR] Refer to the generated Javadoc files in '/Users/ar026626/git/jdbcmetrics/target/apidocs' dir.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

Removing the '&' in the Javadoc fixes this issue.