### PR TITLE
Disable the default builds report generation function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<closeTestReports>true</closeTestReports>
 	</properties>
 
 	<parent>
@@ -132,6 +133,7 @@
 					<includes>
 						<include>**/*.java</include>
 					</includes>
+					<disableXmlReport>${closeTestReports}</disableXmlReport>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.